### PR TITLE
Randomized string to avoid Mac OS cache issue

### DIFF
--- a/500px-osx-background.sh
+++ b/500px-osx-background.sh
@@ -67,6 +67,9 @@ fi
 #  CONFIGURATION END
 # --- --- --- --- ---
 
+# randomize string
+RANDOMIZER=$(date +%s)
+
 # getting feed from 500px
 curl -s "$FEED"|grep "$NEEDLE_TAG"|awk -F$NEEDLE_SRC_ATTR'=\"' '{print $2}'|awk -F'"' '{print $1}' > $DIR/500px_list.txt
 
@@ -84,9 +87,12 @@ for i in $(seq 1 $COUNT); do
 
 	# getting the image url from index
 	IMG=`cat $DIR/500px_list.txt|tail -n +$RND|head -n 1`
+	
+	# deleting previous imgs
+	rm $DIR/500px_img*
 
 	# getting image data from url
-	curl -s "$IMG" -o $DIR/500px_img.png
+	curl -s "$IMG" -o $DIR/500px_img_$RANDOMIZER.png
 
 	# getting image dimensions
 	IMG_W=`sips -g pixelWidth $DIR/500px_img.png|tail -n 1|awk '{print $2}'`
@@ -103,7 +109,7 @@ done
 if [ $FOUND ]; then
 	# setting image as background
 	echo "Setting downloaded image as background"
-	osascript -e 'tell application "System Events" to set picture of every desktop to ("'$DIR'/500px_img.png" as POSIX file as alias)'
+	osascript -e 'tell application "System Events" to set picture of every desktop to ("'$DIR'/500px_img_'$RANDOMIZER'.png" as POSIX file as alias)'
 else
 	echo "No image found"
 fi


### PR DESCRIPTION
When fetching and setting the new background, Mac OS doesn’t actually change the background. As the filename doesn’t change (500px_img.png), Mac OS doesn’t refresh the background. Randomizing the filename by adding the timestamp (ex : 500px_img_1512054747.png) seems to force Mac OS to refresh the background.

Signed-off-by: Clément TISSIER <clement.tissier@amelys-info.com>