### PR TITLE
Fix for wrong url (in search.rss response)

### DIFF
--- a/500px-osx-background.sh
+++ b/500px-osx-background.sh
@@ -95,8 +95,8 @@ for i in $(seq 1 $COUNT); do
 	curl -s "$IMG" -o $DIR/500px_img_$RANDOMIZER.png
 
 	# getting image dimensions
-	IMG_W=`sips -g pixelWidth $DIR/500px_img.png|tail -n 1|awk '{print $2}'`
-	IMG_H=`sips -g pixelHeight $DIR/500px_img.png|tail -n 1|awk '{print $2}'`
+	IMG_W=`sips -g pixelWidth $DIR/500px_img_$RANDOMIZER.png|tail -n 1|awk '{print $2}'`
+	IMG_H=`sips -g pixelHeight $DIR/500px_img_$RANDOMIZER.png|tail -n 1|awk '{print $2}'`
 	echo "Image size is ${IMG_W} x ${IMG_H}"
 
 	# checking if image is "good"

--- a/500px-osx-background.sh
+++ b/500px-osx-background.sh
@@ -18,7 +18,7 @@ ONLY_LANDSCAPE_MODE=1
 DIR="/tmp"
 
 # specify feed source type; available options: user, search, popular, upcoming, fresh, editors
-SRC_TYPE="user"
+SRC_TYPE="search"
 
 # needles
 NEEDLE_TAG="<img"
@@ -71,7 +71,7 @@ fi
 RANDOMIZER=$(date +%s)
 
 # getting feed from 500px
-curl -s "$FEED"|grep "$NEEDLE_TAG"|awk -F$NEEDLE_SRC_ATTR'=\"' '{print $2}'|awk -F'"' '{print $1}' > $DIR/500px_list.txt
+curl -s "$FEED"|grep "$NEEDLE_TAG"|awk -F$NEEDLE_SRC_ATTR'=\"' '{print $2}'|awk -F'"' '{print $1}'|sed 's/\&amp;/\&/' > $DIR/500px_list.txt
 
 # getting elements count
 COUNT=`cat $DIR/500px_list.txt|wc -l|awk '{print $1}'`


### PR DESCRIPTION
Thanks a lot for work nice work.

This is a small fix from me. 
Currently, the search.rss return the url with `&amp;` like this:
`<media:content url="https://drscdn.500px.org/photo/73851459/m%3D900/v2?webp=true&amp;sig=ddfa9a6ed0577d9b9fbd9b6277e81d865642456c6d49c81c6702c54a930b8701" type="image/jpeg" medium="image" isDefault="true"/>`

This need to be replaced by `&` to be able to get the image.

Regards,
Vu